### PR TITLE
Fix error in inlinks sql example's groupby clause

### DIFF
--- a/sql/inlinks.sql
+++ b/sql/inlinks.sql
@@ -12,7 +12,7 @@ WITH
 		link.Address.Full AS FullAddress,
           	COUNT(q.Address) AS InLinks
 	FROM q, UNNEST(Links) AS link
-	GROUP BY link.Address )
+	GROUP BY link.Address.Full )
 
 -- Result is a table with information about addresses appearing as
 -- links.  Because it's possible a page is linked to without being in


### PR DESCRIPTION
Fix error "Grouping by expressions of type STRUCT is not allowed at [15:18]"
when running example in BigQuery.

![2019-11-14_20-24](https://user-images.githubusercontent.com/849044/68916647-1f166580-0724-11ea-9757-9d9f3befd654.png)